### PR TITLE
Add support for python 3

### DIFF
--- a/setup.command
+++ b/setup.command
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-import StringIO
+try:
+    import StringIO
+except ImportError:
+    import io as StringIO
 import struct
 import os
 import sys
@@ -29,7 +32,7 @@ def get_images(path):
     result = []
     for img in filtered_items:
         width, height = 0, 0
-        with open(PHOTO_PATH + '/' + path + '/' + img) as f:
+        with open(PHOTO_PATH + '/' + path + '/' + img, 'rb') as f:
             _, width, height = getImageInfo(f.read())
         result.append({
             'width': width,


### PR DESCRIPTION
In python 3, `StringIO` is now just `io`. So it'll import `StringIO` on python 2 and `io` on python 3.

`open()` will now open each file as a binary, I think it was defaulting to opening it as a text file so I was getting encoding errors.

These changes seemed to work for me, and thanks for the awesome tool!